### PR TITLE
atan2 function wrongly uses 16bit int on c2000

### DIFF
--- a/libopeninv/src/sine_core.cpp
+++ b/libopeninv/src/sine_core.cpp
@@ -97,8 +97,8 @@ uint16_t SineCore::Atan2(int32_t x, int32_t y)
    if(y==0)
       return (x>=0 ? 0 : BRAD_PI);
 
-   static const int fixShift = 15;
-   int  phi = 0, t, t2, dphi;
+   static const uint16_t fixShift = 15;
+   int32_t  phi = 0, t, t2, dphi;
 
    if (y < 0)
    {


### PR DESCRIPTION
c2000 int type is 16 bit (max 7fff).
atan2() function uses t= (y << 15) / x
  - left shifts an int32 by 15
  - and takes resulting t as int(16) to the power of two
This lead to wrong calculations and zeroing
rotor angels. Using int32 fixes this. Largest value
during calculations of t= (y << fixShift) / x
can be (7fff << 15) = 3fff8000 or smaller on 12bit ADC.
x is always > y. Thus we are safe there with following t*t;

Fixed by using int32.